### PR TITLE
fix: remove unused type ignore comment

### DIFF
--- a/src/litestar_email/backends/__init__.py
+++ b/src/litestar_email/backends/__init__.py
@@ -182,7 +182,7 @@ def get_backend(
     if not accepts_kwargs:
         backend_kwargs = {key: value for key, value in backend_kwargs.items() if key in init_signature.parameters}
 
-    return backend_class(**backend_kwargs)  # type: ignore[call-arg]
+    return backend_class(**backend_kwargs)
 
 
 def list_backends() -> list[str]:


### PR DESCRIPTION
## Summary

- Removes unused `# type: ignore[call-arg]` comment from `backends/__init__.py:185`
- Fixes mypy CI failure (run ID: 20699443414)

## Test Plan

- [x] `make lint` passes locally
- [x] `make test` passes locally (79 tests)

## Notes

The Documentation Build failure (run ID: 20699443415) is **not addressed** by this PR as it requires enabling GitHub Pages in the repository settings at Settings > Pages. The workflow code itself is correct.