### PR TITLE
fix(smtp): prevent double STARTTLS causing "Connection already using TLS" error

### DIFF
--- a/src/litestar_email/backends/smtp.py
+++ b/src/litestar_email/backends/smtp.py
@@ -116,6 +116,7 @@ class SMTPBackend(BaseEmailBackend):
             port=self._config.port,
             timeout=self._config.timeout,
             use_tls=self._config.use_ssl,  # use_tls in aiosmtplib means implicit SSL
+            start_tls=False,  # Disable auto-STARTTLS
         )
 
         try:

--- a/src/tests/test_smtp_backend.py
+++ b/src/tests/test_smtp_backend.py
@@ -336,3 +336,105 @@ async def test_smtp_backend_starttls_upgrade() -> None:
         await backend.open()
 
         mock_smtp.starttls.assert_called_once()
+
+
+async def test_smtp_backend_starttls_no_double_call() -> None:
+    """Test that start_tls=False is passed to aiosmtplib to prevent double STARTTLS.
+
+    Regression test for: SMTP STARTTLS executed twice causes
+    'Connection already using TLS' error when aiosmtplib auto-detects
+    STARTTLS support and litestar-email also calls starttls() manually.
+    """
+    from litestar_email.backends.smtp import SMTPBackend
+    from litestar_email.config import SMTPConfig
+
+    config = SMTPConfig(
+        host="smtp.example.com",
+        port=587,
+        use_tls=True,
+        use_ssl=False,
+    )
+    backend = SMTPBackend(config=config)
+
+    with patch("aiosmtplib.SMTP") as mock_smtp_class:
+        mock_smtp = AsyncMock()
+        mock_smtp.connect = AsyncMock()
+        mock_smtp.starttls = AsyncMock()
+        mock_smtp_class.return_value = mock_smtp
+
+        await backend.open()
+
+        # Verify start_tls=False was passed to disable auto-STARTTLS
+        mock_smtp_class.assert_called_once_with(
+            hostname="smtp.example.com",
+            port=587,
+            timeout=30,
+            use_tls=False,
+            start_tls=False,
+        )
+        # Verify manual STARTTLS is still called exactly once
+        mock_smtp.starttls.assert_called_once()
+
+
+async def test_smtp_backend_ssl_does_not_call_starttls() -> None:
+    """Test that implicit SSL (use_ssl=True) does not trigger manual STARTTLS."""
+    from litestar_email.backends.smtp import SMTPBackend
+    from litestar_email.config import SMTPConfig
+
+    config = SMTPConfig(
+        host="smtp.example.com",
+        port=465,
+        use_tls=False,
+        use_ssl=True,
+    )
+    backend = SMTPBackend(config=config)
+
+    with patch("aiosmtplib.SMTP") as mock_smtp_class:
+        mock_smtp = AsyncMock()
+        mock_smtp.connect = AsyncMock()
+        mock_smtp.starttls = AsyncMock()
+        mock_smtp_class.return_value = mock_smtp
+
+        await backend.open()
+
+        # use_tls=True in aiosmtplib means implicit SSL
+        mock_smtp_class.assert_called_once_with(
+            hostname="smtp.example.com",
+            port=465,
+            timeout=30,
+            use_tls=True,
+            start_tls=False,
+        )
+        # No manual STARTTLS for implicit SSL
+        mock_smtp.starttls.assert_not_called()
+
+
+async def test_smtp_backend_no_tls_no_ssl() -> None:
+    """Test plain connection without TLS or SSL does not call starttls."""
+    from litestar_email.backends.smtp import SMTPBackend
+    from litestar_email.config import SMTPConfig
+
+    config = SMTPConfig(
+        host="localhost",
+        port=25,
+        use_tls=False,
+        use_ssl=False,
+    )
+    backend = SMTPBackend(config=config)
+
+    with patch("aiosmtplib.SMTP") as mock_smtp_class:
+        mock_smtp = AsyncMock()
+        mock_smtp.connect = AsyncMock()
+        mock_smtp.starttls = AsyncMock()
+        mock_smtp_class.return_value = mock_smtp
+
+        await backend.open()
+
+        mock_smtp_class.assert_called_once_with(
+            hostname="localhost",
+            port=25,
+            timeout=30,
+            use_tls=False,
+            start_tls=False,
+        )
+        mock_smtp.starttls.assert_not_called()


### PR DESCRIPTION
## Summary

Fix SMTP STARTTLS double execution that causes `EmailConnectionError: SMTP connection error: Connection already using TLS` when using `SMTPConfig(use_tls=True, use_ssl=False)` with any STARTTLS-capable server (port 587).

Closes litestar-org/litestar-email#19

## Problem

When connecting to an SMTP server that supports STARTTLS (e.g., `smtp.office365.com:587`), the TLS upgrade is executed **twice**:

| Step | Actor | What happens |
|------|-------|-------------|
| 1 | litestar-email | Creates `aiosmtplib.SMTP` **without passing `start_tls`** (defaults to `None`) |
| 2 | aiosmtplib | `start_tls=None` → auto-detect → server supports STARTTLS → **auto-upgrades** ✅ |
| 3 | litestar-email | `use_tls=True` → **manually calls `starttls()` again** → 💥 `Connection already using TLS` |

This affects **all SMTP servers requiring STARTTLS** (Office 365, Gmail, AWS SES, etc.), making the documented `use_tls=True` + `use_ssl=False` configuration completely broken.

## Solution

Explicitly pass `start_tls=False` to `aiosmtplib.SMTP()` to disable its auto-STARTTLS negotiation, letting litestar-email manage the STARTTLS upgrade manually as intended:

```python
self._connection = aiosmtplib.SMTP(
    hostname=self._config.host,
    port=self._config.port,
    timeout=self._config.timeout,
    use_tls=self._config.use_ssl,
    start_tls=False,  # Disable auto-STARTTLS; we manage it manually below
)
```

This is the minimal, non-breaking fix (Option A from the issue). The existing manual `starttls()` call remains the single point of TLS upgrade.

## Changes

- **`src/litestar_email/backends/smtp.py`** — Add `start_tls=False` parameter to `aiosmtplib.SMTP()` constructor
- **`src/tests/test_smtp_backend.py`** — Add 3 regression tests:
  - `test_smtp_backend_starttls_no_double_call` — Verifies `start_tls=False` is passed and manual `starttls()` is called exactly once
  - `test_smtp_backend_ssl_does_not_call_starttls` — Verifies implicit SSL (`use_ssl=True`) does not trigger manual STARTTLS
  - `test_smtp_backend_no_tls_no_ssl` — Verifies plain connection does not call STARTTLS

## Checklist

- [x] `make test` passes (129 tests)
- [x] `make lint` passes (ruff, mypy, pyright, slotscheck)
- [x] Regression tests added
- [x] No breaking changes
